### PR TITLE
Upgraded logback to 1.2.3 eliminating vulnerability CVE-2017-5929

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
   </modules>
 
   <properties>
-    <version.logback>1.1.3</version.logback>
+    <version.logback>1.2.3</version.logback>
     <version.jboss-logging>3.2.1.Final</version.jboss-logging>
     <version.junit>4.11</version.junit>
     <version.clojure>1.7.0</version.clojure>


### PR DESCRIPTION
There is a critical (9.8) severity vulnerability in logback-core 1.1.3. Please refer to #19 for more details.

All tests have passed.